### PR TITLE
[COOK-2000] Make mode of sshd_config a configurable option

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,6 +37,13 @@ default['openssh']['service_name'] = case node['platform_family']
                                        "ssh"
                                      end
 
+default['openssh']['config_mode'] = case node['platform_family']
+                                     when "rhel", "fedora"
+                                       "0600"
+                                     else
+                                       "0644"
+                                     end
+
 # ssh config group
 default['openssh']['client']['host'] = "*"
 # default['openssh']['client']['forward_agent'] = "no"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,7 +65,7 @@ end
 
 template "/etc/ssh/sshd_config" do
   source "sshd_config.erb"
-  mode '0644'
+  mode  node['openssh']['config_mode']
   owner 'root'
   group 'root'
   variables(:settings => node['openssh']['server'])


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2000

The default recipe currently hard-codes mode 0644 for sshd_config. That doesn't agree with the default mode on some platforms (RedHat, others?), and I'm being asked to comply with the CIS benchmark which calls for mode 0600.

This trivial patch adds a config_mode attribute which defaults to 0600 on RHEL/Fedora and 0644 elsewhere, but can be overridden as desired.
