### PR TITLE
Converted the openssh client/server options to a sorted hash for idempotency

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -67,7 +67,7 @@ if node['openssh']['listen_interfaces']
 end
 
 sorted_server ||= Hash.new
-node['openssh']['client'].sort.map{ |k,v| sorted_server[k] = v }
+node['openssh']['server'].sort.map{ |k,v| sorted_server[k] = v }
 
 template "/etc/ssh/sshd_config" do
   source "sshd_config.erb"


### PR DESCRIPTION
If you override the openssh options in an application cookbook via node.set, chef-client will evaluate the option hash in a non-deterministic way, creating a different option file in each run hence ruining idempotency (and restarts the openssh server every time).

Sorting the hash before exporting it to the template, solves this issue.

Please see COOK-2066 for further information.
