### PR TITLE
Remove iptables dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,4 +12,4 @@ recipe "openssh::iptables", "Set up iptables to allow SSH inbound"
   supports os
 end
 
-depends "iptables"
+suggests "iptables"


### PR DESCRIPTION
There are many different ways to manage firewall rules so there should not be a dependency on the iptables cookbook.
