### PR TITLE
[COOK-3910] Use Upstart provider for Ubuntu 13.10

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,11 @@ node['openssh']['package_name'].each do |name|
   package name
 end
 
+service_provider = Chef::Provider::Service::Upstart if 'ubuntu' == node['platform'] &&
+  Chef::VersionConstraint.new('>= 13.10').include?(node['platform_version'])
+
 service 'ssh' do
+  provider service_provider
   service_name node['openssh']['service_name']
   supports value_for_platform(
     'debian' => { 'default' => [:restart, :reload, :status] },


### PR DESCRIPTION
Ubuntu 13.10 deprecates managing OpenSSH with init script if upstart init method is used (default).

Ticket: https://tickets.opscode.com/browse/COOK-3910

There's no regression tests for this issue, but when Ubuntu 13.10 box and chef omnibus support will be released by Opscode, Ubuntu 13.10 can be added to `.kitchen.yml` and integration suite will fail without this PR.
