### PR TITLE
Ubuntu 12.04 uses upstart

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,7 +27,7 @@ node['openssh']['package_name'].each do |name|
 end
 
 service_provider = Chef::Provider::Service::Upstart if 'ubuntu' == node['platform'] &&
-  Chef::VersionConstraint.new('>= 13.10').include?(node['platform_version'])
+  Chef::VersionConstraint.new('>= 12.04').include?(node['platform_version'])
 
 service 'ssh' do
   provider service_provider


### PR DESCRIPTION
Ubuntu 12.04 uses upstart for openssh.  This PR changes the constraint to match.
