### PR TITLE
The RHEL/Fedora server package is openssh-server

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,7 +23,7 @@
 
 default['openssh']['package_name'] = case node['platform_family']
                                      when 'rhel', 'fedora'
-                                       %w[openssh-clients openssh]
+                                       %w[openssh-clients openssh-server]
                                      when 'arch', 'suse', 'gentoo'
                                        %w[openssh]
                                      when 'freebsd'


### PR DESCRIPTION
Not openssh. Both the client and server packages depend on openssh so
it is not necessary to state this one explicitly. This probably went
unnoticed for so long because openssh-server is installed as part of
the @core set.
