### PR TITLE
Add version lock on iptables

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ recipe 'openssh::iptables', 'Set up iptables to allow SSH inbound'
   supports os
 end
 
-depends 'iptables'
+depends 'iptables', "~> 1.0"
 
 source_url 'https://github.com/chef-cookbooks/openssh' if respond_to?(:source_url)
 issues_url 'https://github.com/chef-cookbooks/openssh/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
Adding a pessimistic lock to version 1 of iptables because version 2 is not compatible with chef 11