### PR TITLE
Update default.rb

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,6 +65,9 @@ if 'ubuntu' == node['platform']
   elsif Chef::VersionConstraint.new('>= 12.04').include?(node['platform_version'])
     service_provider = Chef::Provider::Service::Upstart
   end
+  unless node[:openssh][:server][:subsystem].nil?
+    node.override['openssh']['server']['subsystem'] = 'sftp /usr/lib/openssh/sftp-server'
+  end
 end
 
 service 'ssh' do


### PR DESCRIPTION
Added a condition to handle default attribute for the sftp subsystem that maps to the incorrect location on Ubuntu 14.04. I added this change so the end user does not need to be aware when un-commenting the sftp subsystem attribute in attribute/default.rb will not correctly enable sftp in the sshd_config file.