### PR TITLE
Restore sshd restart

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -50,6 +50,7 @@ template '/etc/ssh/sshd_config' do
   group  node['root_group']
   variables(options: openssh_server_options)
   notifies :run, 'execute[sshd-config-check]', :immediately
+  notifies :restart, 'service[ssh]'
 end
 
 execute 'sshd-config-check' do


### PR DESCRIPTION
I noticed today that when I change my sshd config with chef that the changes made it into my config file, but the SSH server didn't change behaviour.

I have traced this back to the fact that the default cookbook verifies the config is valid, but the line that restarts the SSH server was recently removed here: https://github.com/chef-cookbooks/openssh/commit/7eb21592443603edebd35d09698d11b8b6ef8499

This commit restores the restart line to where it was originally.