### PR TITLE
Do not set UseRoaming for Centos <= 6.7

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,7 +50,13 @@ default['openssh']['config_mode'] = case node['platform_family']
 default['openssh']['client']['host'] = '*'
 
 # Workaround for CVE-2016-0777 and CVE-2016-0778
-default['openssh']['client']['use_roaming'] = 'no'
+if node['platform_family'] == 'rhel'
+  if Chef::VersionConstraint.new('> 6.7').include?(node['platform_version'])
+    default['openssh']['client']['use_roaming'] = 'no'
+  end
+else
+  default['openssh']['client']['use_roaming'] = 'no'
+end
 # default['openssh']['client']['forward_agent'] = 'no'
 # default['openssh']['client']['forward_x11'] = 'no'
 # default['openssh']['client']['rhosts_rsa_authentication'] = 'no'

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -14,6 +14,12 @@ describe port(22) do
   it { should be_listening }
 end
 
+use_roaming = if os[:family] == 'centos' && os[:release].to_i < 7
+                nil
+              else
+                'no'
+              end
+
 describe ssh_config do
-  its('UseRoaming') { should eq 'no' }
+  its('UseRoaming') { should eq use_roaming }
 end


### PR DESCRIPTION
The OpenSSH client code between 5.4 and 7.1 contains experimental support for resuming SSH-connections (roaming). Setting UseRoaming unconditionally for openssh versions that do not have that feature leads to:

"/etc/ssh/ssh_config line 5: Bad yes/no argument."

when running ssh client as configured by the openssh cookbook. This patch sets UseRoaming only for Centos > 6.7. Centos 5.11 and 6.7 openssh packages do not have this experimental code and, thus, are not exposed to the vulnerability.

Fixes #77