### PR TITLE
Add support for multiple sshd ports.

### DIFF
--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -59,4 +59,18 @@ describe 'openssh::default' do
         .with_content(/# Do NOT modify this file by hand!\n\nPort 1234/)
     end
   end
+
+  context 'supports multiple ports' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new do |node|
+        node.set['openssh']['server']['port'] = [1234, 1235]
+      end.converge(described_recipe)
+    end
+
+    it 'writes both ports to sshd_config' do
+      expect(chef_run).to render_file('/etc/ssh/sshd_config')
+        .with_content(/Port 1234/)
+        .with_content(/Port 1235/)
+    end
+  end
 end

--- a/spec/unit/recipes/iptables_spec.rb
+++ b/spec/unit/recipes/iptables_spec.rb
@@ -26,4 +26,18 @@ describe 'openssh::iptables' do
         .with_content('-A FWR -p tcp -m tcp --dport 4242 -j ACCEPT')
     end
   end
+
+  context 'supports multiple ports' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(step_into: ['iptables_rule']) do |node|
+        node.set['openssh']['server']['port'] = [1234, 1235]
+      end.converge(described_recipe)
+    end
+
+    it 'contains both ports from' do
+      expect(chef_run).to render_file('/etc/iptables.d/port_ssh')
+        .with_content('-A FWR -p tcp -m tcp --dport 1234 -j ACCEPT')
+        .with_content('-A FWR -p tcp -m tcp --dport 1235 -j ACCEPT')
+    end
+  end
 end

--- a/templates/default/port_ssh.erb
+++ b/templates/default/port_ssh.erb
@@ -1,2 +1,8 @@
 # SSH
+<% if @port.kind_of? Array -%>
+<%   @port.each do |item| -%>
+-A FWR -p tcp -m tcp --dport <%= item %> -j ACCEPT
+<%   end -%>
+<% else -%>
 -A FWR -p tcp -m tcp --dport <%= @port %> -j ACCEPT
+<% end -%>


### PR DESCRIPTION
While support for rendering multiple ports to sshd_config
already existed, the cookbook would not properly render
an iptables rule.