### PR TITLE
Adds support for multiple SSH subsystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,31 @@ StrictHostKeyChecking no
 UserKnownHostsFile /dev/null
 ```
 
+### SSH Subsystems
+
+Configure multiple SSH subsystems (e.g. sftp, netconf):
+
+```json
+"openssh": {
+  "server": {
+    "subsystem": {
+      "sftp": "/usr/lib/openssh/sftp-server",
+      "appX": "/usr/sbin/appX"
+    } 
+  }
+}
+```
+
+Former declaration of single subsystem:
+ 
+```json
+"openssh": {
+  "server": {
+    "subsystem": "sftp /usr/lib/openssh/sftp-server"
+  }
+}
+```
+
 ## License & Authors
 
 **Author:** Cookbook Engineering Team ([cookbooks@chef.io](mailto:cookbooks@chef.io))

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -23,7 +23,7 @@
 module Openssh
   module Helpers
     def openssh_server_options
-      options = node['openssh']['server'].sort.reject { |key, _value| key == 'port' || key == 'match' }
+      options = node['openssh']['server'].sort.reject { |key, _value| key == 'port' || key == 'match' || key == 'subsystem' }
       unless node['openssh']['server']['port'].nil?
         port = node['openssh']['server'].select { |key| key == 'port' }.to_a
         options.unshift(*port)

--- a/templates/default/sshd_config.erb
+++ b/templates/default/sshd_config.erb
@@ -11,6 +11,20 @@
 <%  end -%>
 <% end -%>
 
+<%  if defined?(node['openssh']['server']['subsystem']) -%>
+<%    if  node['openssh']['server']['subsystem'].is_a?(Hash) -%>
+<%      node['openssh']['server']['subsystem'].map do |subsystem_name, subsystem_value| -%>
+Subsystem <%= subsystem_name %> <%= subsystem_value %>
+<%      end -%>
+<%    elsif node['openssh']['server']['subsystem'].is_a?(Array) -%>
+<%      node['openssh']['server']['subsystem'].each do |subsystem| -%>
+Subsystem <%= subsystem %>
+<%      end -%>
+<%    elsif node['openssh']['server']['subsystem'].is_a?(String) -%>
+Subsystem <%= node['openssh']['server']['subsystem'] %>
+<%    end -%>
+<%  end -%>
+
 <%  unless node['openssh']['server']['match'].empty? || !defined?(node['openssh']['server']['match']) -%>
 <%    node['openssh']['server']['match'].sort.map do |match_key, match_items| -%>
 Match <%= match_key %>


### PR DESCRIPTION
### Description

This commit will add support for including multiple Subsystem statements in sshd_config file (tipically SFTP but other protocols could make use of this feature, e.g., NETCONF via SSH).

The node.openssh.subystem attribute is it converted to a Hash and processed like a Match block in order to add multiple statements. 

The PR includes tests to assert the generation of the sshd_config file with multiple Subsystem options.
### Check List
- [\* ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ *] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ *] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
