### PR TITLE
EL7 intentionally lacks of auto-gen'd DSA key

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -90,6 +90,13 @@ default['openssh']['client']['use_roaming'] = 'no' unless node['platform_family'
 if platform_family?('smartos')
   default['openssh']['server']['host_key'] = ['/var/ssh/ssh_host_rsa_key', '/var/ssh/ssh_host_dsa_key']
 end
+if platform_family?('rhel') && node['platform_version'].to_i == 7
+  # EL7 does not generate a DSA key by default like EL6 used to, yet
+  # the upstream OpenSSH code wants to find one, so continually spits
+  # out a harmless error line to syslog. So we explicitly indicate the
+  # HostKey files that are auto-generated on an EL7 host
+  default['openssh']['server']['host_key'] = ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key']
+end
 # default['openssh']['server']['host_key_ecdsa'] = '/etc/ssh/ssh_host_ecdsa_key'
 # default['openssh']['server']['key_regeneration_interval'] = '1h'
 # default['openssh']['server']['server_key_bits'] = '1024'


### PR DESCRIPTION
### Description

EL7 does not generate a DSA key by default like EL6 used to, yet the upstream OpenSSH code wants to find one, so continually spits out a harmless error line to syslog. So we explicitly indicate the HostKey files that are auto-generated on an EL7 host

### Issues Resolved

https://github.com/chef-cookbooks/openssh/issues/61

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


Fixes #61

EL7 does not generate a DSA key by default like EL6 used to, yet the upstream OpenSSH code wants to find one, so continually spits out a harmless error line to syslog. So we explicitly indicate the HostKey files that are auto-generated on an EL7 host