### PR TITLE
Basic Mac OS support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,14 +26,14 @@ default['openssh']['package_name'] = case node['platform_family']
                                        %w(openssh-clients openssh-server)
                                      when 'arch', 'suse', 'gentoo'
                                        %w(openssh)
-                                     when 'freebsd', 'smartos'
+                                     when 'freebsd', 'smartos', 'mac_os_x'
                                        %w()
                                      else
                                        %w(openssh-client openssh-server)
                                      end
 
 default['openssh']['service_name'] = case node['platform_family']
-                                     when 'rhel', 'fedora', 'suse', 'freebsd', 'gentoo', 'arch'
+                                     when 'rhel', 'fedora', 'suse', 'freebsd', 'gentoo', 'arch', 'mac_os_x'
                                        'sshd'
                                      else
                                        'ssh'


### PR DESCRIPTION
### Description
Implements the most basic Mac OS support.

### Issues Resolved
No issue in the tracker. The change makes openssh::default work on Mac OS. Package and service name are the same as for BSD. Enables attribute-based sshd_config generation.

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


Signed-off-by: Anna Tikhonova <anna.m.tikhonova@gmail.com>