### PR TITLE
RHEL 6 (and CentOS 6) openssh generates its certs in /etc/ssh/

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -87,8 +87,12 @@ default['openssh']['client']['use_roaming'] = 'no' unless node['platform_family'
 # default['openssh']['server']['host_key_v1'] = '/etc/ssh/ssh_host_key'
 # default['openssh']['server']['host_key_rsa'] = '/etc/ssh/ssh_host_rsa_key'
 # default['openssh']['server']['host_key_dsa'] = '/etc/ssh/ssh_host_dsa_key'
-if platform_family?('smartos') || (platform_family?('rhel') && node['platform_version'].to_i == 6)
+if platform_family?('smartos')
   default['openssh']['server']['host_key'] = ['/var/ssh/ssh_host_rsa_key', '/var/ssh/ssh_host_dsa_key']
+end
+
+if (platform_family?('rhel') && node['platform_version'].to_i == 6)
+  default['openssh']['server']['host_key'] = ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_dsa_key']
 end
 
 if (platform_family?('rhel') && node['platform_version'].to_i == 7) || platform?('amazon') || platform_family?('debian')

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -91,7 +91,7 @@ if platform_family?('smartos')
   default['openssh']['server']['host_key'] = ['/var/ssh/ssh_host_rsa_key', '/var/ssh/ssh_host_dsa_key']
 end
 
-if (platform_family?('rhel') && node['platform_version'].to_i == 6)
+if platform_family?('rhel') && node['platform_version'].to_i == 6
   default['openssh']['server']['host_key'] = ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_dsa_key']
 end
 


### PR DESCRIPTION
Addresses https://github.com/chef-cookbooks/openssh/issues/54

### Description

As per comments in https://github.com/chef-cookbooks/openssh/issues/54

RHEL 6 and CentOS 6 both generate SSL certs in `/etc/ssh/` as opposed to `/var/ssh/`

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing. - N/A no new functionality, and tests already exist
- [X] New functionality has been documented in the README if applicable - N/A no new functionality
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
