### PR TITLE
Test that ssh to localhost works.

### DIFF
--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -22,3 +22,11 @@ end
 describe ssh_config do
   its('UseRoaming') { should eq use_roaming_value }
 end
+
+# Attempt to ssh to localhost
+describe command('ssh -oStrictHostKeyChecking=no -v localhost') do
+  # No way of actually sshing in without a keypair or password
+  # but being prompted for an authentication method should be sufficient to
+  # test that SSH is working as expected, for the most part
+  its('stderr') { should match 'Next authentication method' }
+end


### PR DESCRIPTION
This test fails with the Dokken .kitchen.yml, used by Travis CI, when run against v2.4.0 of the cookbook.
It passes against the latest version on my branch (6276ab70b).

It's not a particularly nice test, so I've not (yet?) included it in my PR
https://github.com/chef-cookbooks/openssh/pull/103

Signed-off-by: Lucy Davies <lucy@lucymhdavies.com>

### Description

Test mentioned in https://github.com/chef-cookbooks/openssh/pull/103

This should fail in Travis CI for centos-6.

### Issues Resolved

Causes v2.4.0 to fail in Travis CI (Dokken)

Change from https://github.com/chef-cookbooks/openssh/pull/103 will cause this test to pass

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>

This test should FAIL in TravisCI until https://github.com/chef-cookbooks/openssh/pull/103 is merged.

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
