### PR TITLE
Generate host keys when missing on Fedora / RHEL 7+

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,6 +9,9 @@ verifier:
   name: inspec
 
 platforms:
+  - name: amazonlinux
+    driver_config:
+      box: mvbcoding/awslinux
   - name: centos-6
   - name: centos-7
   - name: debian-7
@@ -27,9 +30,6 @@ platforms:
     run_list: apt::default
   - name: ubuntu-16.04
     run_list: apt::default
-  - name: amazonlinux
-    driver_config:
-      box: mvbcoding/awslinux
   - name: macosx-10.11
     run_list: homebrew::default
     driver:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     #  - INSTANCE=default-debian-7 # fails due to missing /var/run/sshd in docker
   - INSTANCE=default-debian-8
   - INSTANCE=default-debian-9
-    # - INSTANCE=default-fedora-latest needs keys generated first in docker
+  - INSTANCE=default-fedora-latest
   - INSTANCE=default-centos-6
   - INSTANCE=default-centos-7
   - INSTANCE=default-opensuse-leap

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,24 @@ services: docker
 
 env:
   matrix:
-  - INSTANCE=default-ubuntu-1404
-  - INSTANCE=default-ubuntu-1604
-    #  - INSTANCE=default-debian-7 # fails due to missing /var/run/sshd in docker
-  - INSTANCE=default-debian-8
-  - INSTANCE=default-debian-9
-  - INSTANCE=default-fedora-latest
-  - INSTANCE=default-centos-6
-  - INSTANCE=default-centos-7
-  - INSTANCE=default-opensuse-leap
+  - CHEF_VERSION=12 INSTANCE=default-ubuntu-1404
+  - CHEF_VERSION=12 INSTANCE=default-ubuntu-1604
+    # - CHEF_VERSION=12 INSTANCE=default-debian-7 # fails due to missing /var/run/sshd in docker
+  - CHEF_VERSION=12 INSTANCE=default-debian-8
+  - CHEF_VERSION=12 INSTANCE=default-debian-9
+  - CHEF_VERSION=12 INSTANCE=default-fedora-latest
+  - CHEF_VERSION=12 INSTANCE=default-centos-6
+  - CHEF_VERSION=12 INSTANCE=default-centos-7
+  - CHEF_VERSION=12 INSTANCE=default-opensuse-leap
+  - CHEF_VERSION=13 INSTANCE=default-ubuntu-1404
+  - CHEF_VERSION=13 INSTANCE=default-ubuntu-1604
+    # - CHEF_VERSION=13 INSTANCE=default-debian-7 # fails due to missing /var/run/sshd in docker
+  - CHEF_VERSION=13 INSTANCE=default-debian-8
+  - CHEF_VERSION=13 INSTANCE=default-debian-9
+  - CHEF_VERSION=13 INSTANCE=default-fedora-latest
+  - CHEF_VERSION=13 INSTANCE=default-centos-6
+  - CHEF_VERSION=13 INSTANCE=default-centos-7
+  - CHEF_VERSION=13 INSTANCE=default-opensuse-leap
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
@@ -36,7 +45,7 @@ before_script:
   - cookstyle --version
   - foodcritic --version
 
-script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen verify ${INSTANCE}
+script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml CHEF_VERSION=${CHEF_VERSION} kitchen verify ${INSTANCE}
 
 matrix:
   include:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -92,11 +92,8 @@ default['openssh']['client']['use_roaming'] = 'no' unless node['platform_family'
 # default['openssh']['server']['host_key_v1'] = '/etc/ssh/ssh_host_key'
 # default['openssh']['server']['host_key_rsa'] = '/etc/ssh/ssh_host_rsa_key'
 # default['openssh']['server']['host_key_dsa'] = '/etc/ssh/ssh_host_dsa_key'
-if platform_family?('smartos')
-  default['openssh']['server']['host_key'] = ['/var/ssh/ssh_host_rsa_key', '/var/ssh/ssh_host_dsa_key']
-end
 
-if platform_family?('rhel') && node['platform_version'].to_i == 6
+if (platform_family?('rhel') && node['platform_version'].to_i == 6) || platform_family?('smartos')
   default['openssh']['server']['host_key'] = ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_dsa_key']
 end
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -97,7 +97,7 @@ if (platform_family?('rhel') && node['platform_version'].to_i == 6) || platform_
   default['openssh']['server']['host_key'] = ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_dsa_key']
 end
 
-if (platform_family?('rhel') && node['platform_version'].to_i == 7) || platform?('amazon') || platform_family?('debian')
+if (platform_family?('rhel') && node['platform_version'].to_i >= 7) || platform?('amazon', 'fedora') || platform_family?('debian')
   # EL7 does not generate a DSA key by default like EL6 used to, yet
   # the upstream OpenSSH code wants to find one, so continually spits
   # out a harmless error line to syslog. So we explicitly indicate the

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1,8 +1,0 @@
-def openssh_server_options
-  options = node['openssh']['server'].sort.reject { |key, _value| key == 'port' || key == 'match' }
-  unless node['openssh']['server']['port'].nil?
-    port = node['openssh']['server'].select { |key| key == 'port' }.to_a
-    options.unshift(*port)
-  end
-  options
-end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -31,16 +31,19 @@ module Openssh
       options
     end
 
+    # path to the sshd-keygen binary
     def sshd_keygen_command
       platform_family?('rhel') ? '/usr/sbin/sshd-keygen' : '/usr/libexec/openssh/sshd-keygen'
     end
 
+    # are we on a platform that has the sshd-keygen command. It's a redhat-ism so it's a limited number
     def keygen_platform?
       platform_family?('rhel', 'fedora') &&
         node['platform_version'].to_i >= 7 &&
         !platform?('amazon')
     end
 
+    # are any of the host keys defined in the attribute missing from the filesystem
     def sshd_host_keys_missing?
       !node['openssh']['server']['host_key'].all? { |f| ::File.exist?(f) }
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,50 @@
+#
+# Cookbook:: openssh
+# library:: helpers
+#
+# Copyright:: 2016-2017, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attributes are commented out using the default config file values.
+# Uncomment the ones you need, or set attributes in a role.
+#
+
+module Openssh
+  module Helpers
+    def openssh_server_options
+      options = node['openssh']['server'].sort.reject { |key, _value| key == 'port' || key == 'match' }
+      unless node['openssh']['server']['port'].nil?
+        port = node['openssh']['server'].select { |key| key == 'port' }.to_a
+        options.unshift(*port)
+      end
+      options
+    end
+
+    def sshd_keygen_command
+      platform_family?('rhel') ? '/usr/sbin/sshd-keygen' : '/usr/libexec/openssh/sshd-keygen'
+    end
+
+    def keygen_platform?
+      platform_family?('rhel', 'fedora') &&
+        node['platform_version'].to_i >= 7 &&
+        !platform?('amazon')
+    end
+
+    def sshd_host_keys_missing?
+      !node['openssh']['server']['host_key'].all? { |f| ::File.exist?(f) }
+    end
+  end
+end
+
+Chef::Resource.send(:include, ::Openssh::Helpers)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -31,11 +31,6 @@ module Openssh
       options
     end
 
-    # path to the sshd-keygen binary
-    def sshd_keygen_command
-      platform_family?('rhel') ? '/usr/sbin/sshd-keygen' : '/usr/libexec/openssh/sshd-keygen'
-    end
-
     # are we on a platform that has the sshd-keygen command. It's a redhat-ism so it's a limited number
     def keygen_platform?
       platform_family?('rhel', 'fedora') &&
@@ -51,3 +46,4 @@ module Openssh
 end
 
 Chef::Resource.send(:include, ::Openssh::Helpers)
+Chef::Recipe.send(:include, ::Openssh::Helpers)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -63,7 +63,6 @@ template '/etc/ssh/sshd_config' do
   owner 'root'
   group node['root_group']
   variables(options: openssh_server_options)
-  notifies :start, 'service[sshd-keygen]', :immediately
   notifies :run, 'execute[sshd-config-check]', :immediately
   notifies :restart, 'service[ssh]'
 end
@@ -73,10 +72,10 @@ execute 'sshd-config-check' do
   action :nothing
 end
 
-service 'sshd-keygen' do
-  supports [:restart, :reload, :status]
-  action :nothing
-  only_if { ::File.exist?('/usr/lib/systemd/system/sshd-keygen.service') }
+execute 'generate sshd host keys' do
+  command sshd_keygen_command
+  action :run
+  only_if { keygen_platform? && sshd_host_keys_missing? }
 end
 
 service 'ssh' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,6 +57,8 @@ template 'sshd_revoked_keys_file' do
   group node['root_group']
 end
 
+# this will only execute on RHEL / Fedora systems where sshd has never been started
+# 99.99% of the time this is going to be a docker container
 if keygen_platform? && sshd_host_keys_missing?
   if platform?('fedora')
     node['openssh']['server']['host_key'].each do |key|

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,6 +57,12 @@ template 'sshd_revoked_keys_file' do
   group node['root_group']
 end
 
+execute 'generate sshd host keys' do
+  command sshd_keygen_command
+  action :run
+  only_if { keygen_platform? && sshd_host_keys_missing? }
+end
+
 template '/etc/ssh/sshd_config' do
   source 'sshd_config.erb'
   mode node['openssh']['config_mode']
@@ -70,12 +76,6 @@ end
 execute 'sshd-config-check' do
   command '/usr/sbin/sshd -t'
   action :nothing
-end
-
-execute 'generate sshd host keys' do
-  command sshd_keygen_command
-  action :run
-  only_if { keygen_platform? && sshd_host_keys_missing? }
 end
 
 service 'ssh' do


### PR DESCRIPTION
This is necessary in Docker containers where sshd has never started. Without this the Chef run will fail since the sshd config validation fails when it can't find the keys. It's a bit complex, but it does work and the library is in better shape than before so that's progress.