### PR TITLE
Generate missing ssh keys on amazon linux as well

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,9 +21,7 @@ platforms:
   - name: debian-9
     run_list: apt::default
   - name: freebsd-10
-    run_list: freebsd::portsnap
   - name: freebsd-11
-    run_list: freebsd::portsnap
   - name: fedora-26
   - name: opensuse-leap-42
   - name: ubuntu-14.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ services: docker
 
 env:
   matrix:
+  - CHEF_VERSION=12 INSTANCE=default-amazonlinux
   - CHEF_VERSION=12 INSTANCE=default-ubuntu-1404
   - CHEF_VERSION=12 INSTANCE=default-ubuntu-1604
     # - CHEF_VERSION=12 INSTANCE=default-debian-7 # fails due to missing /var/run/sshd in docker
@@ -28,6 +29,7 @@ env:
   - CHEF_VERSION=12 INSTANCE=default-centos-6
   - CHEF_VERSION=12 INSTANCE=default-centos-7
   - CHEF_VERSION=12 INSTANCE=default-opensuse-leap
+  - CHEF_VERSION=13 INSTANCE=default-amazonlinux
   - CHEF_VERSION=13 INSTANCE=default-ubuntu-1404
   - CHEF_VERSION=13 INSTANCE=default-ubuntu-1604
     # - CHEF_VERSION=13 INSTANCE=default-debian-7 # fails due to missing /var/run/sshd in docker

--- a/Berksfile
+++ b/Berksfile
@@ -5,5 +5,4 @@ metadata
 group :integration do
   cookbook 'apt'
   cookbook 'homebrew'
-  cookbook 'freebsd'
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -33,9 +33,8 @@ module Openssh
 
     # are we on a platform that has the sshd-keygen command. It's a redhat-ism so it's a limited number
     def keygen_platform?
-      platform_family?('rhel', 'fedora') &&
-        node['platform_version'].to_i >= 7 &&
-        !platform?('amazon')
+      platform_family?('rhel', 'fedora', 'amazon') &&
+        node['platform_version'].to_i >= 7
     end
 
     # are any of the host keys defined in the attribute missing from the filesystem

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,7 +65,7 @@ if keygen_platform? && sshd_host_keys_missing?
       keytype = key.split('_')[-2]
       execute "/usr/libexec/openssh/sshd-keygen #{keytype}"
     end
-  elsif platform_family?('rhel')
+  elsif platform_family?('rhel', 'amazon')
     execute '/usr/sbin/sshd-keygen'
   end
 end


### PR DESCRIPTION
This only impacts container workloads, but it allows us to test this cookbook and the chef-client itself on amazon

Signed-off-by: Tim Smith <tsmith@chef.io>