### PR TITLE
dont break el5 systems with options that they dont support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -153,8 +153,8 @@ default['openssh']['server']['use_p_a_m'] = 'yes' unless platform_family?('smart
 # default['openssh']['server']['chroot_directory'] = 'none'
 # default['openssh']['server']['banner'] = 'none'
 # default['openssh']['server']['subsystem'] = 'sftp /usr/libexec/sftp-server'
-default['openssh']['server']['trusted_user_c_a_keys'] = '/etc/ssh/ca_keys'
-default['openssh']['server']['revoked_keys'] = '/etc/ssh/revoked_keys'
+default['openssh']['server']['trusted_user_c_a_keys'] = '/etc/ssh/ca_keys' unless node['platform_family'] == 'rhel' && node['platform_version'].to_i < 6
+default['openssh']['server']['revoked_keys'] = '/etc/ssh/revoked_keys' unless node['platform_family'] == 'rhel' && node['platform_version'].to_i < 6
 default['openssh']['server']['subsystem'] = 'sftp /usr/libexec/openssh/sftp-server' if platform_family?('rhel', 'amazon', 'fedora')
 default['openssh']['server']['subsystem'] = 'sftp /usr/lib/openssh/sftp-server' if platform_family?('debian')
 default['openssh']['server']['match'] = {}


### PR DESCRIPTION
Out of the box, el5 systems become unable to start SSH on boot due to the revoked_keys and trusted_user_c_a_keys not being supported on that platform - so exclude them by default on rhel < 6