### PR TITLE
use template verify property instead of notify

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -82,13 +82,8 @@ template '/etc/ssh/sshd_config' do
   owner 'root'
   group node['root_group']
   variables(options: openssh_server_options)
-  notifies :run, 'execute[sshd-config-check]', :immediately
+  verify '/usr/sbin/sshd -t -f %{path}'
   notifies :restart, 'service[ssh]'
-end
-
-execute 'sshd-config-check' do
-  command '/usr/sbin/sshd -t'
-  action :nothing
 end
 
 service 'ssh' do


### PR DESCRIPTION
Signed-off-by: michael.sgarbossa <msgarbossa@cvs.com>

### Description

Performs validation of desired template file before changing the configuration file.  This update replaces the execute block for running the sshd -t command with the verify property of the template resource.  If validation fails, the recipe no longer leaves an invalid configuration on the node.

### Issues Resolved

Resolves #118 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
