### PR TITLE
fix: resolve package validation errors and add sshd_binary property

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -3,6 +3,7 @@ config:
   line-length: false # MD013
   no-duplicate-heading: false # MD024
   reference-links-images: false # MD052
+  table-column-style: false # MD060
   no-multiple-blanks:
     maximum: 2
 ignores:

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -11,11 +11,11 @@ module Openssh
     end
 
     def default_client_package_names
-      platform_family?('rhel', 'fedora', 'amazon') ? %w(openssh-clients) : %w(openssh-client)
+      platform_family?('rhel', 'fedora', 'amazon') ? 'openssh-clients' : 'openssh-client'
     end
 
     def default_server_package_names
-      %w(openssh-server)
+      'openssh-server'
     end
 
     def default_client_global_options

--- a/resources/openssh_client.rb
+++ b/resources/openssh_client.rb
@@ -11,16 +11,17 @@ property :config_path, String, default: lazy { join_path(config_dir, 'ssh_config
 property :mode, String, default: '0644'
 property :global_options, Hash, default: lazy { default_client_global_options }
 property :host_options, Hash, default: lazy { default_client_host_options }
-property :package_names, [String, Array], default: lazy { default_client_package_names }, coerce: proc { |value| Array(value) }
+property :package_names, [String, Array], default: lazy { default_client_package_names }
 
 action_class do
   include Openssh::Helpers
 end
 
 action :create do
-  package new_resource.package_names do
-    action :install
-    only_if { new_resource.manage_package }
+  if new_resource.manage_package
+    package new_resource.package_names do
+      action :install
+    end
   end
 
   file new_resource.config_path do
@@ -36,8 +37,9 @@ action :delete do
     action :delete
   end
 
-  package new_resource.package_names do
-    action :remove
-    only_if { new_resource.manage_package }
+  if new_resource.manage_package
+    package new_resource.package_names do
+      action :remove
+    end
   end
 end

--- a/resources/openssh_server.rb
+++ b/resources/openssh_server.rb
@@ -18,7 +18,8 @@ property :ca_keys, Array, default: []
 property :ca_keys_path, String, default: lazy { join_path(config_dir, 'ca_keys') }
 property :revoked_keys, Array, default: []
 property :revoked_keys_path, String, default: lazy { join_path(config_dir, 'revoked_keys') }
-property :package_names, [String, Array], default: lazy { default_server_package_names }, coerce: proc { |value| Array(value) }
+property :package_names, [String, Array], default: lazy { default_server_package_names }
+property :sshd_binary, String, default: lazy { default_sshd_binary }
 property :service_name, String, default: lazy { default_service_name }
 property :manage_service, [true, false], default: true
 property :generate_host_keys, [true, false], default: true
@@ -43,9 +44,10 @@ action_class do
 end
 
 action :create do
-  package new_resource.package_names do
-    action :install
-    only_if { new_resource.manage_package }
+  if new_resource.manage_package
+    package new_resource.package_names do
+      action :install
+    end
   end
 
   if runtime_directory
@@ -79,7 +81,7 @@ action :create do
       owner new_resource.owner
       group new_resource.group
       mode new_resource.mode
-      verify "#{default_sshd_binary} -t -f %{path}"
+      verify "#{new_resource.sshd_binary} -t -f %{path}"
       notifies :restart, "service[#{new_resource.service_name}]", :delayed if new_resource.manage_service
     end
   else
@@ -131,8 +133,9 @@ action :delete do
     end
   end
 
-  package new_resource.package_names do
-    action :remove
-    only_if { new_resource.manage_package }
+  if new_resource.manage_package
+    package new_resource.package_names do
+      action :remove
+    end
   end
 end

--- a/spec/unit/resources/openssh_client_spec.rb
+++ b/spec/unit/resources/openssh_client_spec.rb
@@ -24,4 +24,14 @@ describe 'openssh_client' do
     it { is_expected.to render_file('/etc/ssh/ssh_config').with_content(/^UseRoaming no$/) }
     it { is_expected.to render_file('/etc/ssh/ssh_config').with_content(/^Host \*$/) }
   end
+
+  context 'with custom package_names' do
+    recipe do
+      openssh_client 'default' do
+        package_names %w(openssh-client ssh-askpass)
+      end
+    end
+
+    it { is_expected.to install_package(%w(openssh-client ssh-askpass)) }
+  end
 end

--- a/spec/unit/resources/openssh_server_spec.rb
+++ b/spec/unit/resources/openssh_server_spec.rb
@@ -36,6 +36,30 @@ describe 'openssh_server' do
     it { is_expected.to render_file('/etc/ssh/sshd_config').with_content(/^UsePAM yes$/) }
   end
 
+  context 'with custom sshd_binary' do
+    recipe do
+      openssh_server 'default' do
+        sshd_binary '/usr/lib/ssh/sshd'
+      end
+    end
+
+    it 'uses the custom binary for config verification' do
+      file = chef_run.file('/etc/ssh/sshd_config')
+      commands = file.verify.map { |v| v.instance_variable_get(:@command) }
+      expect(commands).to include('/usr/lib/ssh/sshd -t -f %{path}')
+    end
+  end
+
+  context 'with custom package_names' do
+    recipe do
+      openssh_server 'default' do
+        package_names %w(openssh-server openssh-sftp-server)
+      end
+    end
+
+    it { is_expected.to install_package(%w(openssh-server openssh-sftp-server)) }
+  end
+
   context 'with custom ports and trust data' do
     recipe do
       openssh_server 'default' do


### PR DESCRIPTION
# Summary

- Replace `only_if` (run-time) guard with compile-time `if` for `manage_package`. The `only_if` guard still compiles and validates the `package` resource even when `manage_package` is `false`, causing `windows_package` to reject Array values at compile time.

- Default `package_names` helpers to return a String instead of a single-element Array, and remove the `coerce` proc that forced values to Array. Chef's `package` resource accepts both String and Array natively, so this is safe and avoids the `windows_package` validation issue entirely.

- Add `sshd_binary` property to `openssh_server` so wrapper cookbooks can override the binary path used for config verification. The default `/usr/sbin/sshd` is incorrect on platforms like Windows (`C:\Program Files\OpenSSH\sshd.exe`).

- Add specs for `sshd_binary` and multi-package array handling.

# Issues Resolved

## 1. `Chef::Exceptions::ValidationFailed` when wrapper cookbooks use `step_into`

```
Chef::Exceptions::ValidationFailed: Option package_name must be a kind of String!  You passed ["openssh-server"].
```

The `package_names` property coerces all values to Array, and the `only_if { new_resource.manage_package }` guard is a run-time check — the `package` resource is still compiled and validated at compile time. On Windows, where the `windows_package` provider only accepts `String` for `package_name`, this causes a validation failure even when `manage_package` is `false`.

## 2. Config verification fails on non-standard sshd paths

```
Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '127'
---- Begin output of /usr/sbin/sshd -t -f /etc/ssh/sshd_config ----
```

The `verify` command hardcodes `/usr/sbin/sshd`, which doesn't exist on platforms like Windows (`C:\Program Files\OpenSSH\sshd.exe`).

## Checklist

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Tests added for both changes
- [x] No changes to `metadata.rb`, `CHANGELOG.md`, or version tags