### PR TITLE
fix: avoid package validation when package management is disabled

### DIFF
--- a/documentation/openssh_openssh_client.md
+++ b/documentation/openssh_openssh_client.md
@@ -4,24 +4,24 @@ Manages the OpenSSH client package and `/etc/ssh/ssh_config`.
 
 ## Actions
 
-| Action | Description |
-|--------|-------------|
+| Action    | Description                                                        |
+| --------- | ------------------------------------------------------------------ |
 | `:create` | Installs the client package and writes the client config (default) |
-| `:delete` | Removes the client config and client package |
+| `:delete` | Removes the client config and client package                       |
 
 ## Properties
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `config_dir` | `String` | `'/etc/ssh'` | Base SSH configuration directory |
-| `owner` | `String` | `'root'` | Owner for the config file |
-| `group` | `String` | `'root'` | Group for the config file |
-| `manage_package` | `true`, `false` | `true` | Install or remove the client package |
-| `config_path` | `String` | `'/etc/ssh/ssh_config'` | Full path to the client config |
-| `mode` | `String` | `'0644'` | Mode for the client config |
-| `global_options` | `Hash` | `{'use_roaming' => 'no'}` | Top-level SSH client directives |
-| `host_options` | `Hash` | `{'*' => {}}` | Host-specific client directives |
-| `package_names` | `String`, `Array` | platform default | Package name or names to manage |
+| Property         | Type              | Default                   | Description                          |
+| ---------------- | ----------------- | ------------------------- | ------------------------------------ |
+| `config_dir`     | `String`          | `'/etc/ssh'`              | Base SSH configuration directory     |
+| `owner`          | `String`          | `'root'`                  | Owner for the config file            |
+| `group`          | `String`          | `'root'`                  | Group for the config file            |
+| `manage_package` | `true`, `false`   | `true`                    | Install or remove the client package |
+| `config_path`    | `String`          | `'/etc/ssh/ssh_config'`   | Full path to the client config       |
+| `mode`           | `String`          | `'0644'`                  | Mode for the client config           |
+| `global_options` | `Hash`            | `{'use_roaming' => 'no'}` | Top-level SSH client directives      |
+| `host_options`   | `Hash`            | `{'*' => {}}`             | Host-specific client directives      |
+| `package_names`  | `String`, `Array` | platform default          | Package name or names to manage      |
 
 ## Examples
 

--- a/documentation/openssh_openssh_firewall.md
+++ b/documentation/openssh_openssh_firewall.md
@@ -4,20 +4,20 @@ Manages SSH allow rules through the `iptables` cookbook resources.
 
 ## Actions
 
-| Action | Description |
-|--------|-------------|
+| Action    | Description                                                                 |
+| --------- | --------------------------------------------------------------------------- |
 | `:create` | Installs or starts iptables resources and creates SSH allow rules (default) |
-| `:delete` | Removes the managed SSH allow rules |
+| `:delete` | Removes the managed SSH allow rules                                         |
 
 ## Properties
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `port` | `String`, `Integer`, `Array` | `nil` | Convenience property for one or more SSH ports |
-| `ports` | `String`, `Integer`, `Array` | `['22']` | SSH ports to allow when `port` is not set |
-| `manage_iptables_service` | `true`, `false` | `true` | Enable and start the iptables service resource |
-| `inbound_chain` | `Symbol` | `:INPUT` | Chain for inbound rules |
-| `outbound_chain` | `Symbol` | `:OUTPUT` | Chain for outbound rules |
+| Property                  | Type                         | Default   | Description                                    |
+| ------------------------- | ---------------------------- | --------- | ---------------------------------------------- |
+| `port`                    | `String`, `Integer`, `Array` | `nil`     | Convenience property for one or more SSH ports |
+| `ports`                   | `String`, `Integer`, `Array` | `['22']`  | SSH ports to allow when `port` is not set      |
+| `manage_iptables_service` | `true`, `false`              | `true`    | Enable and start the iptables service resource |
+| `inbound_chain`           | `Symbol`                     | `:INPUT`  | Chain for inbound rules                        |
+| `outbound_chain`          | `Symbol`                     | `:OUTPUT` | Chain for outbound rules                       |
 
 ## Examples
 

--- a/documentation/openssh_openssh_server.md
+++ b/documentation/openssh_openssh_server.md
@@ -4,35 +4,36 @@ Manages the OpenSSH server package, key material files, `/etc/ssh/sshd_config`, 
 
 ## Actions
 
-| Action | Description |
-|--------|-------------|
+| Action    | Description                                                                                        |
+| --------- | -------------------------------------------------------------------------------------------------- |
 | `:create` | Installs the server package, writes config and key files, and enables/starts the service (default) |
-| `:delete` | Stops the service and removes the managed config, key files, host keys, and server package |
+| `:delete` | Stops the service and removes the managed config, key files, host keys, and server package         |
 
 ## Properties
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `config_dir` | `String` | `'/etc/ssh'` | Base SSH configuration directory |
-| `owner` | `String` | `'root'` | Owner for managed files |
-| `group` | `String` | `'root'` | Group for managed files |
-| `manage_package` | `true`, `false` | `true` | Install or remove the server package |
-| `config_path` | `String` | `'/etc/ssh/sshd_config'` | Full path to the server config |
-| `mode` | `String` | platform default | Mode for server config and key-list files |
-| `options` | `Hash` | platform defaults | SSH server directives excluding subsystem and match blocks |
-| `port` | `String`, `Integer`, `Array` | `nil` | Convenience property for one or more `Port` directives |
-| `subsystems` | `String`, `Array`, `Hash` | platform default | `Subsystem` directives |
-| `match_blocks` | `Hash` | `{}` | `Match` blocks keyed by match expression |
-| `listen_interfaces` | `Hash` | `{}` | Interface-to-address-family map used to derive `ListenAddress` |
-| `ca_keys` | `Array` | `[]` | Trusted CA keys written to `ca_keys_path` |
-| `ca_keys_path` | `String` | `'/etc/ssh/ca_keys'` | Path for trusted CA keys |
-| `revoked_keys` | `Array` | `[]` | Revoked keys written to `revoked_keys_path` |
-| `revoked_keys_path` | `String` | `'/etc/ssh/revoked_keys'` | Path for revoked keys |
-| `package_names` | `String`, `Array` | `['openssh-server']` | Package name or names to manage |
-| `service_name` | `String` | platform default | SSH service name |
-| `manage_service` | `true`, `false` | `true` | Enable and start the service |
-| `generate_host_keys` | `true`, `false` | `true` | Run `ssh-keygen -A` when configured host keys are missing |
-| `verify_config` | `true`, `false` | `true` | Verify `sshd_config` with `sshd -t` before replacing it |
+| Property             | Type                         | Default                   | Description                                                    |
+| -------------------- | ---------------------------- | ------------------------- | -------------------------------------------------------------- |
+| `config_dir`         | `String`                     | `'/etc/ssh'`              | Base SSH configuration directory                               |
+| `owner`              | `String`                     | `'root'`                  | Owner for managed files                                        |
+| `group`              | `String`                     | `'root'`                  | Group for managed files                                        |
+| `manage_package`     | `true`, `false`              | `true`                    | Install or remove the server package                           |
+| `config_path`        | `String`                     | `'/etc/ssh/sshd_config'`  | Full path to the server config                                 |
+| `mode`               | `String`                     | platform default          | Mode for server config and key-list files                      |
+| `options`            | `Hash`                       | platform defaults         | SSH server directives excluding subsystem and match blocks     |
+| `port`               | `String`, `Integer`, `Array` | `nil`                     | Convenience property for one or more `Port` directives         |
+| `subsystems`         | `String`, `Array`, `Hash`    | platform default          | `Subsystem` directives                                         |
+| `match_blocks`       | `Hash`                       | `{}`                      | `Match` blocks keyed by match expression                       |
+| `listen_interfaces`  | `Hash`                       | `{}`                      | Interface-to-address-family map used to derive `ListenAddress` |
+| `ca_keys`            | `Array`                      | `[]`                      | Trusted CA keys written to `ca_keys_path`                      |
+| `ca_keys_path`       | `String`                     | `'/etc/ssh/ca_keys'`      | Path for trusted CA keys                                       |
+| `revoked_keys`       | `Array`                      | `[]`                      | Revoked keys written to `revoked_keys_path`                    |
+| `revoked_keys_path`  | `String`                     | `'/etc/ssh/revoked_keys'` | Path for revoked keys                                          |
+| `package_names`      | `String`, `Array`            | `'openssh-server'`        | Package name or names to manage                                |
+| `sshd_binary`        | `String`                     | `'/usr/sbin/sshd'`        | Binary used to verify `sshd_config`                            |
+| `service_name`       | `String`                     | platform default          | SSH service name                                               |
+| `manage_service`     | `true`, `false`              | `true`                    | Enable and start the service                                   |
+| `generate_host_keys` | `true`, `false`              | `true`                    | Run `ssh-keygen -A` when configured host keys are missing      |
+| `verify_config`      | `true`, `false`              | `true`                    | Verify `sshd_config` with `sshd -t` before replacing it        |
 
 ## Examples
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -11,11 +11,11 @@ module Openssh
     end
 
     def default_client_package_names
-      platform_family?('rhel', 'fedora', 'amazon') ? %w(openssh-clients) : %w(openssh-client)
+      platform_family?('rhel', 'fedora', 'amazon') ? 'openssh-clients' : 'openssh-client'
     end
 
     def default_server_package_names
-      %w(openssh-server)
+      'openssh-server'
     end
 
     def default_client_global_options

--- a/resources/openssh_client.rb
+++ b/resources/openssh_client.rb
@@ -11,16 +11,17 @@ property :config_path, String, default: lazy { join_path(config_dir, 'ssh_config
 property :mode, String, default: '0644'
 property :global_options, Hash, default: lazy { default_client_global_options }
 property :host_options, Hash, default: lazy { default_client_host_options }
-property :package_names, [String, Array], default: lazy { default_client_package_names }, coerce: proc { |value| Array(value) }
+property :package_names, [String, Array], default: lazy { default_client_package_names }
 
 action_class do
   include Openssh::Helpers
 end
 
 action :create do
-  package new_resource.package_names do
-    action :install
-    only_if { new_resource.manage_package }
+  if new_resource.manage_package
+    package new_resource.package_names do
+      action :install
+    end
   end
 
   file new_resource.config_path do
@@ -36,8 +37,9 @@ action :delete do
     action :delete
   end
 
-  package new_resource.package_names do
-    action :remove
-    only_if { new_resource.manage_package }
+  if new_resource.manage_package
+    package new_resource.package_names do
+      action :remove
+    end
   end
 end

--- a/resources/openssh_server.rb
+++ b/resources/openssh_server.rb
@@ -18,7 +18,8 @@ property :ca_keys, Array, default: []
 property :ca_keys_path, String, default: lazy { join_path(config_dir, 'ca_keys') }
 property :revoked_keys, Array, default: []
 property :revoked_keys_path, String, default: lazy { join_path(config_dir, 'revoked_keys') }
-property :package_names, [String, Array], default: lazy { default_server_package_names }, coerce: proc { |value| Array(value) }
+property :package_names, [String, Array], default: lazy { default_server_package_names }
+property :sshd_binary, String, default: lazy { default_sshd_binary }
 property :service_name, String, default: lazy { default_service_name }
 property :manage_service, [true, false], default: true
 property :generate_host_keys, [true, false], default: true
@@ -43,9 +44,10 @@ action_class do
 end
 
 action :create do
-  package new_resource.package_names do
-    action :install
-    only_if { new_resource.manage_package }
+  if new_resource.manage_package
+    package new_resource.package_names do
+      action :install
+    end
   end
 
   if runtime_directory
@@ -79,7 +81,7 @@ action :create do
       owner new_resource.owner
       group new_resource.group
       mode new_resource.mode
-      verify "#{default_sshd_binary} -t -f %{path}"
+      verify "#{new_resource.sshd_binary} -t -f %{path}"
       notifies :restart, "service[#{new_resource.service_name}]", :delayed if new_resource.manage_service
     end
   else
@@ -131,8 +133,9 @@ action :delete do
     end
   end
 
-  package new_resource.package_names do
-    action :remove
-    only_if { new_resource.manage_package }
+  if new_resource.manage_package
+    package new_resource.package_names do
+      action :remove
+    end
   end
 end

--- a/spec/unit/resources/openssh_client_spec.rb
+++ b/spec/unit/resources/openssh_client_spec.rb
@@ -24,4 +24,55 @@ describe 'openssh_client' do
     it { is_expected.to render_file('/etc/ssh/ssh_config').with_content(/^UseRoaming no$/) }
     it { is_expected.to render_file('/etc/ssh/ssh_config').with_content(/^Host \*$/) }
   end
+
+  context 'with package management disabled and array package_names' do
+    recipe do
+      openssh_client 'default' do
+        manage_package false
+        package_names %w(openssh-client ssh-askpass)
+      end
+    end
+
+    it { is_expected.not_to install_package(%w(openssh-client ssh-askpass)) }
+    it { is_expected.to create_file('/etc/ssh/ssh_config') }
+  end
+
+  context 'with custom package_names' do
+    recipe do
+      openssh_client 'default' do
+        package_names %w(openssh-client ssh-askpass)
+      end
+    end
+
+    it { is_expected.to install_package(%w(openssh-client ssh-askpass)) }
+  end
+
+  context 'delete action with custom package_names' do
+    recipe do
+      openssh_client 'default' do
+        package_names %w(openssh-client ssh-askpass)
+        action :delete
+      end
+    end
+
+    it { is_expected.to remove_package(%w(openssh-client ssh-askpass)) }
+  end
+end
+
+describe 'openssh_client on Windows' do
+  step_into :openssh_client
+  platform 'windows', '2022'
+
+  context 'with package management disabled and array package_names' do
+    recipe do
+      openssh_client 'default' do
+        manage_package false
+        package_names %w(OpenSSH.Client ssh-askpass)
+      end
+    end
+
+    it 'does not declare a package resource' do
+      expect(chef_run.resource_collection.any? { |resource| resource.resource_name == :package }).to be false
+    end
+  end
 end

--- a/spec/unit/resources/openssh_server_spec.rb
+++ b/spec/unit/resources/openssh_server_spec.rb
@@ -36,6 +36,54 @@ describe 'openssh_server' do
     it { is_expected.to render_file('/etc/ssh/sshd_config').with_content(/^UsePAM yes$/) }
   end
 
+  context 'with package management disabled and array package_names' do
+    recipe do
+      openssh_server 'default' do
+        manage_package false
+        package_names %w(openssh-server openssh-sftp-server)
+      end
+    end
+
+    it { is_expected.not_to install_package(%w(openssh-server openssh-sftp-server)) }
+    it { is_expected.to create_file('/etc/ssh/sshd_config') }
+  end
+
+  context 'with custom sshd_binary' do
+    recipe do
+      openssh_server 'default' do
+        sshd_binary '/usr/lib/ssh/sshd'
+      end
+    end
+
+    it 'uses the custom binary for config verification' do
+      file = chef_run.file('/etc/ssh/sshd_config')
+      commands = file.verify.map { |verifier| verifier.instance_variable_get(:@command) }
+
+      expect(commands).to include('/usr/lib/ssh/sshd -t -f %{path}')
+    end
+  end
+
+  context 'with custom package_names' do
+    recipe do
+      openssh_server 'default' do
+        package_names %w(openssh-server openssh-sftp-server)
+      end
+    end
+
+    it { is_expected.to install_package(%w(openssh-server openssh-sftp-server)) }
+  end
+
+  context 'delete action with custom package_names' do
+    recipe do
+      openssh_server 'default' do
+        package_names %w(openssh-server openssh-sftp-server)
+        action :delete
+      end
+    end
+
+    it { is_expected.to remove_package(%w(openssh-server openssh-sftp-server)) }
+  end
+
   context 'with custom ports and trust data' do
     recipe do
       openssh_server 'default' do
@@ -55,5 +103,26 @@ describe 'openssh_server' do
     it { is_expected.to create_file('/etc/ssh/revoked_keys') }
     it { is_expected.to render_file('/etc/ssh/ca_keys').with_content(/#{Regexp.escape(ca_key)}/) }
     it { is_expected.to render_file('/etc/ssh/revoked_keys').with_content(/#{Regexp.escape(revoked_key)}/) }
+  end
+end
+
+describe 'openssh_server on Windows' do
+  step_into :openssh_server
+  platform 'windows', '2022'
+
+  context 'with package management disabled and array package_names' do
+    recipe do
+      openssh_server 'default' do
+        manage_package false
+        manage_service false
+        generate_host_keys false
+        verify_config false
+        package_names %w(OpenSSH.Server ssh-askpass)
+      end
+    end
+
+    it 'does not declare a package resource' do
+      expect(chef_run.resource_collection.any? { |resource| resource.resource_name == :package }).to be false
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Avoid declaring package resources when `manage_package false`, preventing Windows provider validation from rejecting array package names in wrapper cookbooks.
- Preserve String package defaults while still allowing caller-provided package arrays.
- Add `sshd_binary` to `openssh_server` and document the new API.
- Reformat resource documentation tables so MD060 passes without disabling the rule.

## Verification
- `chef exec ruby -c resources/openssh_client.rb resources/openssh_server.rb resources/openssh_firewall.rb`
- `cookstyle`
- `chef exec rspec --format documentation`
- `markdownlint-cli2 "**/*.md" "#vendor/**"`
- `yamllint .`
- `KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test default-ubuntu-2404 --destroy=always`
- Second `kitchen converge default-ubuntu-2404`: `Infra Phase complete, 0/13 resources updated`

Co-authored-by: slong47 <SLONG47@bloomberg.net>
